### PR TITLE
fix(graph): fix topological sort

### DIFF
--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -72,9 +72,9 @@ func TestGraph_TopologicalSort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotOrderedIndexes, gotCyclic := tt.sut.TopologicalSort()
-			assert.Equal(t, gotCyclic, tt.wantCyclic)
-			if tt.wantCyclic {
-				assert.ElementsMatch(t, gotOrderedIndexes, tt.wantOrderedIndexes)
+			assert.Equal(t, tt.wantCyclic, gotCyclic)
+			if !tt.wantCyclic {
+				assert.Equal(t, tt.wantOrderedIndexes, gotOrderedIndexes)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request refactors the `TopologicalSort` method in the `Graph` type to improve clarity and correctness and updates the corresponding test cases to align with the changes. The key changes include reworking the dependency graph representation, fixing a documentation error, and modifying test assertions.

### Refactoring and correctness improvements:
* [`graph/graph.go`](diffhunk://#diff-53970b87d6fa462d888bbc4aa9f8a438ff2112de7c7483df4de67b67a74c93eaL34-R44): Reversed the dependency graph representation in the `TopologicalSort` method to use a reverse adjacency list (`dep`) instead of the original adjacency list (`g.dependency`). This ensures that the algorithm processes dependencies in the correct direction. [[1]](diffhunk://#diff-53970b87d6fa462d888bbc4aa9f8a438ff2112de7c7483df4de67b67a74c93eaL34-R44) [[2]](diffhunk://#diff-53970b87d6fa462d888bbc4aa9f8a438ff2112de7c7483df4de67b67a74c93eaR57-R70)
* [`graph/graph.go`](diffhunk://#diff-53970b87d6fa462d888bbc4aa9f8a438ff2112de7c7483df4de67b67a74c93eaR57-R70): Updated the condition to detect cycles by comparing the length of `orderedIndexes` with the size of the reversed dependency graph (`len(dep)`) instead of the original graph.

### Documentation fixes:
* [`graph/graph.go`](diffhunk://#diff-53970b87d6fa462d888bbc4aa9f8a438ff2112de7c7483df4de67b67a74c93eaL34-R44): Fixed an error in the method comment for `TopologicalSort` to correctly describe the dependency relationship.

### Test updates:
* [`graph/graph_test.go`](diffhunk://#diff-3918d7e9b8b63efd933d6c795dce887f20d0d1f5389fe903709909fdf1d21265L75-R77): Updated the test assertions in `TestGraph_TopologicalSort` to use `assert.Equal` for ordered index comparisons when no cycle is detected, ensuring the tests reflect the updated behavior of the `TopologicalSort` method.